### PR TITLE
Added PHPMyAdmin Addon

### DIFF
--- a/pma/README.md
+++ b/pma/README.md
@@ -6,7 +6,11 @@ Easily install PHPMyAdmin for your Docksal project. Make it easy to access the d
 fin addon install pma
 ```
 
-## Usage once installed
+## URL
+
+After the installation PhpMyAdmin will be available at `http://pma.<project_name>.docksal`
+
+## Command line reference
 
 - `fin pma disable` to disable
 - `fin pma enable` to re-enable

--- a/pma/README.md
+++ b/pma/README.md
@@ -1,0 +1,12 @@
+# PHPMyAdmin
+
+Easily install PHPMyAdmin for your Docksal project. Make it easy to access the database and examine directly rather then through the CLI.
+
+```bash
+fin addon install pma
+```
+
+## Usage once installed
+
+- `fin pma disable` to disable
+- `fin pma enable` to re-enable

--- a/pma/conf/pma.yml
+++ b/pma/conf/pma.yml
@@ -1,0 +1,10 @@
+  # PHPMyAdmin
+  pma:
+    hostname: pma
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_HOST=db
+      - PMA_USER=root
+      - PMA_PASSWORD=${MYSQL_ROOT_PASSWORD:-root}
+    labels:
+      - io.docksal.virtual-host=pma.${VIRTUAL_HOST}

--- a/pma/pma
+++ b/pma/pma
@@ -22,9 +22,7 @@ DOCKSAL_YML=".docksal/docksal.yml"
 DOCKSAL_YML_NEW=".docksal/docksal.yml.new"
 DOCKSAL_ENV=".docksal/docksal.env"
 DOCKSAL_STACKS="$HOME/.docksal/stacks"
-PHP_INI=".docksal/etc/php/php.ini"
-MAILHOG_INI="$ADDON_ROOT/conf/pma.ini"
-MAILHOG_YML="$ADDON_ROOT/conf/pma.yml"
+PMA_YML="$ADDON_ROOT/conf/pma.yml"
 
 #----------------------------------- YML & config functions ------------------------------------------
 
@@ -92,49 +90,22 @@ yml_remove_service ()
 	fin exec "$CODE_TO_EXEC"
 }
 
-#-------------------------------------- MailHog functions ---------------------------------------------
+#-------------------------------------- PMA functions ---------------------------------------------
 
 # Set/remove proper setting into php.ini
 # $1 - enable/disable
-pma_php_support ()
-{
-	case "$1" in
-		enable)
-			# Create file if not exists
-			if [[ ! -f "$PHP_INI" ]]; then
-				mkdir -p $(dirname "$PHP_INI")
-				echo -e "[php]\n" > "$PHP_INI"
-			fi
-			# Append sendmail setting
-			cat "$MAILHOG_INI" >> "$PHP_INI"
-			# Remove double empty lines for clarity
-			cat -s "$PHP_INI" | tee "$PHP_INI" >/dev/null
-			;;
-		disable)
-			[[ ! -f "$PHP_INI" ]] && return
-			php_ini_contents=$(cat "$PHP_INI")
-			pma_ini_contents=$(cat "$MAILHOG_INI")
-			# Remove all lines that present in pma.ini from php.ini
-			php_ini_contents=${php_ini_contents/$pma_ini_contents/}
-			echo -e "$php_ini_contents" > "$PHP_INI"
-			;;
-	esac
-}
-
 # Enable container and settings
 pma_enable ()
 {
 	# Check that pma is not already enabled
-	if (in_config "image: pma\/pma"); then
-		echo "  Mailhog support is already enabled." && exit
+	if (in_config "image: phpmyadmin\/phpmyadmin"); then
+		echo "  PHPMyAdmin support is already enabled." && exit
 	fi
 
 	echo "  Enabling pma..."
 	yml_prepare
 	# Add pma service to docksal.yml
-	yml_add_service "$MAILHOG_YML"
-	# Add php.ini setting
-	pma_php_support enable
+	yml_add_service "$PMA_YML"
 	# Apply stack changes.
 	fin stop cli
 	fin up
@@ -150,16 +121,14 @@ pma_disable ()
 	fi
 
 	# Make sure pma is installed
-	if ! in_config "image: pma\/pma"; then
-		echo "  Mailhog support is not enabled at the moment." && exit
+	if ! in_config "image: phpmyadmin\/phpmyadmin"; then
+		echo "  PHPMyAdmin support is not enabled at the moment." && exit
 	fi
 
 	echo "  Preparing to remove pma service..."
 	yml_install_tools
 	# Remove pma service from docksal.yml
-	yml_remove_service "mail"
-	# Remove php.ini setting
-	pma_php_support disable
+	yml_remove_service "pma"
 	# Apply stack changes
 	COMPOSE_FILE="" fin stop cli
 	fin up

--- a/pma/pma
+++ b/pma/pma
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+## Enable/disable pma for current project
+##
+## Sub-commands:
+##   enable		Enable pma
+##   disable	Disable pma
+
+red='\033[0;31m'
+green='\033[0;32m'
+green_bg='\033[42m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+echo-red () { echo -e "${red}$1${NC}"; }
+echo-green () { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow () { echo -e "${yellow}$1${NC}"; }
+die () { echo -e "$1"; exit 1; }
+
+DOCKSAL_YML=".docksal/docksal.yml"
+DOCKSAL_YML_NEW=".docksal/docksal.yml.new"
+DOCKSAL_ENV=".docksal/docksal.env"
+DOCKSAL_STACKS="$HOME/.docksal/stacks"
+PHP_INI=".docksal/etc/php/php.ini"
+MAILHOG_INI="$ADDON_ROOT/conf/pma.ini"
+MAILHOG_YML="$ADDON_ROOT/conf/pma.yml"
+
+#----------------------------------- YML & config functions ------------------------------------------
+
+# Check whether given string is in config
+# $1 - string to find
+in_config ()
+{
+	fin config 2>/dev/null | grep "$1" >/dev/null
+}
+
+# Check that docksal.yml is valid
+yml_is_valid ()
+{
+	[[ -f "$DOCKSAL_YML" ]] && $(cat "$DOCKSAL_YML" 2>/dev/null | grep "services" >/dev/null)
+}
+
+# Prepares stack to editing docksal.yml config
+yml_prepare ()
+{
+	# Get yml version to use for a new file from existing stacks
+	YML_VERSION=$(head "$DOCKSAL_STACKS/volumes-bind.yml" | grep "version")
+	YML_DEFAULT_BODY="${YML_VERSION}\nservices:"
+	NEW_STACK='DOCKSAL_STACK="default"'
+
+	# Source docksal.env
+	source "$DOCKSAL_ENV" >/dev/null 2>&1
+
+	# If DOCKSAL_STACK is not set, then...
+	if [[ -z "$DOCKSAL_STACK" ]]; then
+		echo "  Configuring to use DOCKSAL_STACK=\"default\"..."
+		# ...set stack to default so we could use docksal.yml
+		echo -e "$NEW_STACK" >> "$DOCKSAL_ENV"
+	fi
+
+	# Create docksal.yml if needed
+	yml_is_valid || echo -e "$YML_DEFAULT_BODY" >> "$DOCKSAL_YML"
+}
+
+# Install tool required to edit yml from command line
+yml_install_tools ()
+{
+	fin exec "which yaml >/dev/null 2>&1 || npm install --silent -g yaml-cli >/dev/null"
+}
+
+# Add a service to docksal.yml from another yml
+# $1 - filename of yml get service from
+yml_add_service ()
+{
+	[[ -z "$1" ]] && echo "File not found: $1" && return 1
+	# TODO: use https://www.npmjs.com/package/merge-yaml
+	cat "$1" >> "$DOCKSAL_YML"
+}
+
+# Removes a service from docksal.yml
+# $1 - service name
+yml_remove_service ()
+{
+	[[ -z "$1" ]] && echo "Provide a service name to remove" && return 1
+	local service="$1"
+	read -r -d '' CODE_TO_EXEC <<-EOF
+		yaml set $DOCKSAL_YML services.$service | grep -v '$service:' | tee $DOCKSAL_YML_NEW >/dev/null;
+		[[ -z "\$(yaml get $DOCKSAL_YML_NEW services)" ]] && rm '$DOCKSAL_YML' || mv $DOCKSAL_YML_NEW $DOCKSAL_YML
+	EOF
+	# Remove service. If no services left after that, then remove docksal.yml
+	fin exec "$CODE_TO_EXEC"
+}
+
+#-------------------------------------- MailHog functions ---------------------------------------------
+
+# Set/remove proper setting into php.ini
+# $1 - enable/disable
+pma_php_support ()
+{
+	case "$1" in
+		enable)
+			# Create file if not exists
+			if [[ ! -f "$PHP_INI" ]]; then
+				mkdir -p $(dirname "$PHP_INI")
+				echo -e "[php]\n" > "$PHP_INI"
+			fi
+			# Append sendmail setting
+			cat "$MAILHOG_INI" >> "$PHP_INI"
+			# Remove double empty lines for clarity
+			cat -s "$PHP_INI" | tee "$PHP_INI" >/dev/null
+			;;
+		disable)
+			[[ ! -f "$PHP_INI" ]] && return
+			php_ini_contents=$(cat "$PHP_INI")
+			pma_ini_contents=$(cat "$MAILHOG_INI")
+			# Remove all lines that present in pma.ini from php.ini
+			php_ini_contents=${php_ini_contents/$pma_ini_contents/}
+			echo -e "$php_ini_contents" > "$PHP_INI"
+			;;
+	esac
+}
+
+# Enable container and settings
+pma_enable ()
+{
+	# Check that pma is not already enabled
+	if (in_config "image: pma\/pma"); then
+		echo "  Mailhog support is already enabled." && exit
+	fi
+
+	echo "  Enabling pma..."
+	yml_prepare
+	# Add pma service to docksal.yml
+	yml_add_service "$MAILHOG_YML"
+	# Add php.ini setting
+	pma_php_support enable
+	# Apply stack changes.
+	fin stop cli
+	fin up
+}
+
+# Disable container and settings
+pma_disable ()
+{
+	echo "  Running checks..."
+	# Make sure cli container is running
+	if ! (fin ps | grep "_cli_" | grep "Up" >/dev/null); then
+		echo "  ERROR: Start the project with fin start first" && exit 1
+	fi
+
+	# Make sure pma is installed
+	if ! in_config "image: pma\/pma"; then
+		echo "  Mailhog support is not enabled at the moment." && exit
+	fi
+
+	echo "  Preparing to remove pma service..."
+	yml_install_tools
+	# Remove pma service from docksal.yml
+	yml_remove_service "mail"
+	# Remove php.ini setting
+	pma_php_support disable
+	# Apply stack changes
+	COMPOSE_FILE="" fin stop cli
+	fin up
+}
+
+#------------------------------------------ Runtime -----------------------------------------------
+
+cd "$PROJECT_ROOT"
+
+case "$1" in
+	enable)
+		pma_enable
+		;;
+	disable)
+		pma_disable
+		;;
+	*)
+		echo "Usage: fin pma <enable|disable>"
+		exit 1
+		;;
+esac

--- a/pma/pma.filelist
+++ b/pma/pma.filelist
@@ -1,0 +1,7 @@
+# Hooks
+pma.pre-install
+pma.post-install
+pma.pre-uninstall
+
+# Container config
+conf/pma.yml

--- a/pma/pma.post-install
+++ b/pma/pma.post-install
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+fin pma enable
+
+echo -e "${green}PHPMyAdmin UI:${NC} http://pma.<project_name>.docksal"

--- a/pma/pma.pre-install
+++ b/pma/pma.pre-install
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Check Docksal running
+if [[ "$DOCKER_RUNNING" != "true" ]]; then
+	echo "[PRE-INSTALL] ERROR: Docksal and project should be running"
+	exit 1
+fi
+
+# Check Docksal running
+if [[ "$ADDON_GLOBAL" == "true" ]]; then
+	echo -e "[PRE-INSTALL] ERROR: Mailhog addon should not be installed globally"
+	exit 1
+fi
+
+
+# Check project running
+if ! (fin ps | grep "_cli_" | grep "Up" >/dev/null); then
+	echo "[PRE-INSTALL] ERROR: Start the project with fin start first"
+	exit 1
+fi
+
+# Get fin config
+fin_config=$(fin config)
+if [[ $? != 0 ]]; then
+	echo "[PRE-INSTALL] ERROR: 'fin config' command was not successful. Check your fin config"
+	exit 1
+fi
+
+# Check there is no pma already
+if (echo "$fin_config" | grep "image: phpmyadmin\/phpmyadmin"); then
+	echo "[PRE-INSTALL] ERROR: Mailhog seems to be already enabled for this project"
+	exit 1
+fi
+
+# Check there is no pma already
+if (echo "$fin_config" | grep "  mail:"); then
+	echo "[PRE-INSTALL] ERROR: Container named 'mail' already exists. Remove it to continue."
+	exit 1
+fi
+
+
+# All good
+exit 0

--- a/pma/pma.pre-install
+++ b/pma/pma.pre-install
@@ -8,7 +8,7 @@ fi
 
 # Check Docksal running
 if [[ "$ADDON_GLOBAL" == "true" ]]; then
-	echo -e "[PRE-INSTALL] ERROR: Mailhog addon should not be installed globally"
+	echo -e "[PRE-INSTALL] ERROR: PHPMyAdmin addon should not be installed globally"
 	exit 1
 fi
 
@@ -28,13 +28,13 @@ fi
 
 # Check there is no pma already
 if (echo "$fin_config" | grep "image: phpmyadmin\/phpmyadmin"); then
-	echo "[PRE-INSTALL] ERROR: Mailhog seems to be already enabled for this project"
+	echo "[PRE-INSTALL] ERROR: PHPMyAdmin seems to be already enabled for this project"
 	exit 1
 fi
 
 # Check there is no pma already
-if (echo "$fin_config" | grep "  mail:"); then
-	echo "[PRE-INSTALL] ERROR: Container named 'mail' already exists. Remove it to continue."
+if (echo "$fin_config" | grep "  pma:"); then
+	echo "[PRE-INSTALL] ERROR: Container named 'pma' already exists. Remove it to continue."
 	exit 1
 fi
 

--- a/pma/pma.pre-uninstall
+++ b/pma/pma.pre-uninstall
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+fin pma disable


### PR DESCRIPTION
Added ability for users to use PHPMyAdmin using the `phpmyadmin/phpmyadmin` container. This way if the user doesn't have a MySQL client on their local host then they can access using the web based version. Many people are familiar with the PHPMyAdmin set up but some may find it harder to use the CLI. Additionally, when using the Docksal CI/CD approach this would be helpful to access the database and perform any possible debugging.