### PR TITLE
uli - Added auto copying of uli for Linux

### DIFF
--- a/uli/README.md
+++ b/uli/README.md
@@ -1,3 +1,5 @@
 # Drupal one-time login url
 
-Generate one time login url (and on Mac copy it to clipboard)
+* Generate one time login url and:
+  * on Mac copy it to clipboard with `pbcopy`
+  * on Linux copy it to both the selection buffer and clipboard with `xclip`

--- a/uli/uli
+++ b/uli/uli
@@ -13,6 +13,12 @@ uli=$(fin drush uli "$@" 2>&1 | sed "s/default/$VIRTUAL_HOST/" | sed "s/http\:/h
 echo "$uli"
 [[ "$uli" == *"Error"* ]] && exit 1
 
+# Mac OSX copy uli to clipboard with pbcopy
 ( which pbcopy >/dev/null 2>&1 ) &&
 	echo "$uli" | pbcopy &&
 	echo "[+] Copied to clipboard"
+
+# Linux copy uli to both the selection buffer and clipboard with xclip.
+( which xclip >/dev/null 2>&1 ) &&
+	echo "$uli" | xclip -i -sel c -f |xclip -i -sel p &&
+	echo "[+] Copied to clipboard and selection buffer"


### PR DESCRIPTION
If `xclip` is available uli is copied to to clipboard and selection buffer for Linux.
Fixes #13.