### PR TITLE
Add simpletest addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Required fin version is 1.7.0 or higher.
 |   [pma](pma) | [PhpMyAdmin](https://www.phpmyadmin.net/) database management tool | MySQL |
 |   [redis](redis) | Add [Redis](https://redis.io/) to current project |  |
 |   [sequelpro](sequelpro) | Launches [SequelPro](https://www.sequelpro.com) with the connection information for current project. | macOS |
+|   [simpletest](simpletest) | Runs SimpleTest tests in Drupal 7 and 8 | Drupal |
 |   [solr](solr) | [Apache Solr](http://lucene.apache.org/solr/) search service for current project |  |
 |   [uli](uli) | Generate one time login url for current site | Drupal |
 

--- a/simpletest/README.md
+++ b/simpletest/README.md
@@ -1,6 +1,6 @@
 # SimpleTest
 
-Easily run Simpletest tests for your Drupal 7 or 8 project.
+Easily run SimpleTest tests for your Drupal 7 or 8 project.
 
 ```bash
 fin addon install simpletest

--- a/simpletest/README.md
+++ b/simpletest/README.md
@@ -1,0 +1,11 @@
+# SimpleTest
+
+Easily run Simpletest tests for your Drupal 7 or 8 project.
+
+```bash
+fin addon install simpletest
+```
+
+## Usage once installed
+
+Run `fin simpletest` to run the tests. Any additional arguments and options will be appended to the command. For example, to run tests within the `modules/custom` directory, run `fin simpletest --directory modules/custom`.

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+#: exec_target = cli
+
+## Run automated tests with Simpletest.
+##
+## Usage: fin simpletest <args>
+
+cd "${PROJECT_ROOT}/${DOCROOT}"
+
+# Find the run-tests script.
+if [ -f "core/scripts/run-tests.sh" ]; then
+    SCRIPT_FILE="core/scripts/run-tests.sh"
+else
+    SCRIPT_FILE="scripts/run-tests.sh"
+fi
+
+# Execute the script.
+php $SCRIPT_FILE \
+  --php `which php` \
+  --color \
+  $@

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -16,6 +16,5 @@ fi
 
 # Execute the script.
 php $SCRIPT_FILE \
-  --php `which php` \
   --color \
   $@

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -4,7 +4,7 @@
 
 ## Run automated tests with SimpleTest
 ##
-## Usage: fin simpletest [options]
+## Usage: fin simpletest [arguments]
 
 DRUPAL8_PATH="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
 DRUPAL7_PATH="$PROJECT_ROOT/$DOCROOT/scripts/run-tests.sh"

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -6,13 +6,11 @@
 ##
 ## Usage: fin simpletest <args>
 
-cd "${PROJECT_ROOT}/${DOCROOT}"
-
 # Find the run-tests script.
 if [ -f "core/scripts/run-tests.sh" ]; then
-    SCRIPT_FILE="core/scripts/run-tests.sh"
+    SCRIPT_FILE="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
 else
-    SCRIPT_FILE="scripts/run-tests.sh"
+    SCRIPT_FILE="$PROJECT_ROOT/$DOCROOT/scripts/run-tests.sh"
 fi
 
 # Execute the script.

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -2,19 +2,21 @@
 
 #: exec_target = cli
 
-## Run automated tests with SimpleTest.
+## Run automated tests with SimpleTest
 ##
-## Usage: fin simpletest <args>
+## Usage: fin simpletest [options]
 
-# Determine the correct path for the run-tests.sh script. This will depend on
-# the version of Drupal.
-if [ -f "core/scripts/run-tests.sh" ]; then
-    SCRIPT_FILE="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
+DRUPAL8_PATH="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
+DRUPAL7_PATH="$PROJECT_ROOT/$DOCROOT/scripts/run-tests.sh"
+
+if [[ -f "$DRUPAL8_PATH" ]]; then
+	SCRIPT_FILE="$DRUPAL8_PATH"
+elif [[ -f "$DRUPAL7_PATH" ]]; then
+	SCRIPT_FILE="$DRUPAL7_PATH"
 else
-    SCRIPT_FILE="$PROJECT_ROOT/$DOCROOT/scripts/run-tests.sh"
+	echo "ERROR: could not find run-tests.sh"
+	exit 1
 fi
 
 # Execute the script.
-php $SCRIPT_FILE \
-  --color \
-  $@
+php "$SCRIPT_FILE" --color "$@"

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -2,7 +2,7 @@
 
 #: exec_target = cli
 
-## Run automated tests with Simpletest.
+## Run automated tests with SimpleTest.
 ##
 ## Usage: fin simpletest <args>
 

--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -6,7 +6,8 @@
 ##
 ## Usage: fin simpletest <args>
 
-# Find the run-tests script.
+# Determine the correct path for the run-tests.sh script. This will depend on
+# the version of Drupal.
 if [ -f "core/scripts/run-tests.sh" ]; then
     SCRIPT_FILE="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
 else


### PR DESCRIPTION
As the `phpunit` add-on has been added, it seems logical to also have a `simpletest` one which also works for Drupal 7 sites.