### PR TITLE
sequelpro: fix filtering on container label for project name

### DIFF
--- a/sequelpro/sequelpro
+++ b/sequelpro/sequelpro
@@ -7,7 +7,7 @@
 # Abort if anything fails
 set -e
 
-container_port=$(docker ps --all --filter 'label=com.docker.compose.service=db' --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" --format '{{.Ports}}' | sed 's/.*0.0.0.0://g'|sed 's/->.*//g')
+container_port=$(docker ps --all --filter 'label=com.docker.compose.service=db' --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --format '{{.Ports}}' | sed 's/.*0.0.0.0://g'|sed 's/->.*//g')
 HOST=${VIRTUAL_HOST}
 DB=${MYSQL_DATABASE:-default}
 USER=${MYSQL_USER:-user}


### PR DESCRIPTION
We noticed that in a project with dashes in the name (such as "project-name") the sequelpro addon script was looking for containers with a project name in the "safe" form (such as "projectname"), resulting in an error in sequelpro.

By using `${COMPOSE_PROJECT_NAME}` instead sequelpro was able to correctly connect to the database.