### PR TITLE
Fixed default output to docksal.yml file

### DIFF
--- a/pma/pma
+++ b/pma/pma
@@ -58,7 +58,7 @@ yml_prepare ()
 	fi
 
 	# Create docksal.yml if needed
-	yml_is_valid || echo -e "$YML_DEFAULT_BODY" >> "$DOCKSAL_YML"
+	yml_is_valid || echo -e "$YML_DEFAULT_BODY" > "$DOCKSAL_YML"
 }
 
 # Install tool required to edit yml from command line


### PR DESCRIPTION
Changed that default yml body overwrites the `docksal.yml` file instead of appending.

Fixes #20 