### PR TITLE
Fix docksal v.1.12.1 update.

### DIFF
--- a/andock/README.md
+++ b/andock/README.md
@@ -16,7 +16,8 @@ Andock makes it dead simple to get Docksal environments up on your server.
 ## New to Andock:
 * [Introduction](https://andock.readthedocs.io/en/latest/getting-started/introduction/)
 * [15 minutes setup](https://andock.readthedocs.io/en/latest/getting-started/docksal/)
-* [andock command line tool](https://github.com/andock/andock/)
+* [Drupal 8 boilerplate](https://github.com/andock/boilerplate-drupal8)
+* [Andock command line tool](https://github.com/andock/andock/)
 
 ## Addon installation:
 ```bash

--- a/andock/andock
+++ b/andock/andock
@@ -167,10 +167,8 @@ case "$1" in
     else
 	    cmd="$cmd $*"
     fi
-    # Exec andock inside andockio/andock container.
-    export CONTAINER_NAME="andock"
 
     # Execute the command as docker user.
-    fin exec gosu docker /bin/bash -c "export ANDOCK_INSIDE_DOCKSAL=true; export ANDOCK_PROJECT_NAME=${ANDOCK_PROJECT_NAME}; $cmd"
+    fin exec --in=andock gosu docker /bin/bash -c "export ANDOCK_INSIDE_DOCKSAL=true; export ANDOCK_PROJECT_NAME=${ANDOCK_PROJECT_NAME}; $cmd"
 	;;
 esac


### PR DESCRIPTION
Use --in instead of export container to run commands inside andock container.