### PR TITLE
Updated Sequel Pro addon to use safe project name

### DIFF
--- a/sequelpro/sequelpro
+++ b/sequelpro/sequelpro
@@ -7,7 +7,7 @@
 # Abort if anything fails
 set -e
 
-container_port=$(docker ps --all --filter 'label=com.docker.compose.service=db' --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --format '{{.Ports}}' | sed 's/.*0.0.0.0://g'|sed 's/->.*//g')
+container_port=$(docker ps --all --filter 'label=com.docker.compose.service=db' --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" --format '{{.Ports}}' | sed 's/.*0.0.0.0://g'|sed 's/->.*//g')
 HOST=${VIRTUAL_HOST}
 DB=${MYSQL_DATABASE:-default}
 USER=${MYSQL_USER:-user}


### PR DESCRIPTION
+ Fixes an issue where project names containing symbols caused the port to not be found, resulting in a Sequel Pro error.