### PR TITLE
Automatically enable the simpletest module

### DIFF
--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -18,5 +18,10 @@ else
 	exit 1
 fi
 
+SIMPLETEST_STATUS=`drush pm-info simpletest | grep Status | cut -d : -f 2`
+if [[ "$SIMPLETEST_STATUS" != *"enabled"* ]]; then
+  drush pm-enable -y simpletest
+fi
+
 # Execute the script.
 php "$SCRIPT_FILE" --color "$@"


### PR DESCRIPTION
The simpletest module needs to be enabled in order to run tests.

This commit updates the simpletest script to check if the module is enabled, and if not, it will enable the module before running the tests.