### PR TITLE
Add error handling to simpletest add-on

### DIFF
--- a/simpletest/simpletest
+++ b/simpletest/simpletest
@@ -6,6 +6,9 @@
 ##
 ## Usage: fin simpletest [arguments]
 
+set -e
+set -o pipefail
+
 DRUPAL8_PATH="$PROJECT_ROOT/$DOCROOT/core/scripts/run-tests.sh"
 DRUPAL7_PATH="$PROJECT_ROOT/$DOCROOT/scripts/run-tests.sh"
 


### PR DESCRIPTION
Follow up to https://github.com/docksal/addons/pull/49, ensure that the script fails if there are errors, including within pipelines.