### PR TITLE
Initial addon mkcert

### DIFF
--- a/mkcert/README.md
+++ b/mkcert/README.md
@@ -1,0 +1,26 @@
+# Mkcert
+
+This Docksal addon will install mkcert [generate](https://github.com/FiloSottile/mkcert) in the docksal environment. When a certificate for your project is generated the certificate will be trusted by:
+
+- Firefox (Linux & Mac)
+- Chrome & Chromium
+- curl & wget
+- for $VIRTUAL_HOST as well as \*.$VIRTUAL_HOST
+
+## Installation
+The mkcert binary is installed as $HOME/.docksal/bin/mkcert **except** when mkcert is already installed on your system. See installation [instructions](https://github.com/FiloSottile/mkcert#installation).
+```bash
+fin addon install mkcert -g
+```
+## Use
+
+This command has to be executed **once** before ```fin project start``` in every project.
+```bash
+# When you are inside a docksal project
+fin mkcert create
+```
+Note: if you have an already start project you can activate it with:  
+```bash
+fin project stop; sleep 2; fin project start
+```
+Open https://[project].docksal (Or your known URL)

--- a/mkcert/mkcert
+++ b/mkcert/mkcert
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+VERSION="1.0"
+
+## Mkcert addon
+##
+## This is an mkcert addon. 
+## See: https://github.com/FiloSottile/mkcert for details
+## 
+## It creates trusted certificates for $VIRTUAL_HOST and *.$VIRTUAL_HOST
+##
+##   fin mkcert <command>
+##
+## Usage:
+##   create (cr)   Create a certificate for this project
+##   version       Display addon version
+
+CONFIG_CERTS=${CONFIG_CERTS:-$HOME/.docksal/certs}
+
+if [[ "$TERM" != "dumb" ]]; then
+	# Console colors
+	red='\033[0;91m'
+	red_bg='\033[101m'
+	yellow_bg='\033[43m'
+	lightmagenta_bg='\033[0;105m'
+	green='\033[0;32m'
+	green_bg='\033[42m'
+	yellow='\033[0;33m'
+	yellow_bold='\033[1;33m'
+	blue='\033[0;34m'
+	lime='\033[0;92m'
+	acqua='\033[0;96m'
+	magenta='\033[0;35m'
+	lightmagenta='\033[0;95m'
+	NC='\033[0m'
+fi
+
+echo-red ()      { echo -e "${red}$1${NC}"; }
+echo-green ()    { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow ()   { echo -e "${yellow}$1${NC}"; }
+
+echo-warning ()
+{
+	echo -e "${yellow_bg} WARNING: ${NC} ${yellow}$1${NC}";
+	shift
+	for arg in "$@"; do
+		echo -e "           $arg"
+	done
+}
+
+echo-error ()
+{
+	echo -e "${red_bg} ERROR: ${NC} ${red}$1${NC}"
+	shift
+	for arg in "$@"; do
+		echo -e "        $arg"
+	done
+}
+
+echo-alert ()
+{
+	echo -e "${lightmagenta_bg} ALERT: ${NC} ${lightmagenta}$1${NC}"
+	shift
+	for arg in "$@"; do
+		echo -e "         $arg"
+	done
+}
+
+# print string in $1 for $2 times
+echo-repeat ()
+{
+    seq  -f $1 -s '' $2; echo
+}
+
+# prints message to stderr
+echo-stderr ()
+{
+	(>&2 echo "$@")
+}
+
+# Get path to .docksal folder using upfind
+get_project_path ()
+{
+	if [[ "$DOCKSAL_PATH" == "" ]]; then
+		DOCKSAL_PATH=$(upfind ".docksal")
+	fi
+	# If we reached $HOME, then we did not find the project root.
+	if [[ "$DOCKSAL_PATH" != "$HOME" ]]; then
+		echo "$DOCKSAL_PATH"
+	fi
+}
+
+# Check that .docksal is present
+check_project_root ()
+{
+	if [[ "$(get_project_path)" == "" ]] ; then
+		echo-error "Cannot detect project root." \
+			"Please make sure you have ${yellow}.docksal${NC} directory in the root of your project." \
+			"To setup a basic Docksal stack in the current directory run ${yellow}fin config generate${NC}"
+		exit 1
+	fi
+}
+
+
+# Check that project certificate for $VIRTUAL_HOST, else create them
+create_project_certificate ()
+{
+	check_project_root
+	if [[ ! -f "${CONFIG_CERTS}/${VIRTUAL_HOST}.crt" ]]; then
+		mkcert -key-file ${CONFIG_CERTS}/${VIRTUAL_HOST}.key -cert-file ${CONFIG_CERTS}/${VIRTUAL_HOST}.crt *.${VIRTUAL_HOST} ${VIRTUAL_HOST} &>/dev/null
+		if [[ $? == 0 ]]; then
+		  echo-green "Created ssl certificates for ${VIRTUAL_HOST}"
+		else
+		  echo-red "Could not create ssl certificates. Is mkcert still installed?"
+		fi
+	else
+		echo-green "ssl certificates for already exixts as ${CONFIG_CERTS}/${VIRTUAL_HOST}.crt"
+	fi
+}
+
+
+
+case "$1" in
+	create|cr)
+	  create_project_certificate
+	  ;;
+	version|-v)
+		echo "$VERSION"
+		;;
+	*)
+		fin help mkcert
+		;;
+esac

--- a/mkcert/mkcert.pre-install
+++ b/mkcert/mkcert.pre-install
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+CONFIG_DIR="$HOME/.docksal"
+MKCERT_BIN="$CONFIG_DIR/bin/mkcert"
+MKCERT_ADDON="$CONFIG_DIR/addon/mkcert"
+
+REQUIREMENTS_MKCERT=1.4.1
+URL_MKCERT_MAC="https://github.com/FiloSottile/mkcert/releases/download/v${REQUIREMENTS_MKCERT}/mkcert-v${REQUIREMENTS_MKCERT}-darwin-amd64"
+URL_MKCERT_NIX="https://github.com/FiloSottile/mkcert/releases/download/v${REQUIREMENTS_MKCERT}/mkcert-v${REQUIREMENTS_MKCERT}-linux-amd64"
+URL_MKCERT_WIN="https://github.com/FiloSottile/mkcert/releases/download/v${REQUIREMENTS_MKCERT}/mkcert-v${REQUIREMENTS_MKCERT}-windows-amd64.exe"
+
+
+if [[ "$TERM" != "dumb" ]]; then
+	# Console colors
+	red='\033[0;91m'
+	red_bg='\033[101m'
+	yellow_bg='\033[43m'
+	lightmagenta_bg='\033[0;105m'
+	green='\033[0;32m'
+	green_bg='\033[42m'
+	yellow='\033[0;33m'
+	yellow_bold='\033[1;33m'
+	blue='\033[0;34m'
+	lime='\033[0;92m'
+	acqua='\033[0;96m'
+	magenta='\033[0;35m'
+	lightmagenta='\033[0;95m'
+	NC='\033[0m'
+fi
+
+echo-red ()      { echo -e "${red}$1${NC}"; }
+echo-green ()    { echo -e "${green}$1${NC}"; }
+echo-green-bg () { echo -e "${green_bg}$1${NC}"; }
+echo-yellow ()   { echo -e "${yellow}$1${NC}"; }
+
+echo-warning ()
+{
+	echo -e "${yellow_bg} WARNING: ${NC} ${yellow}$1${NC}";
+	shift
+	for arg in "$@"; do
+		echo -e "           $arg"
+	done
+}
+
+echo-error ()
+{
+	echo -e "${red_bg} ERROR: ${NC} ${red}$1${NC}"
+	shift
+	for arg in "$@"; do
+		echo -e "        $arg"
+	done
+}
+
+echo-alert ()
+{
+	echo -e "${lightmagenta_bg} ALERT: ${NC} ${lightmagenta}$1${NC}"
+	shift
+	for arg in "$@"; do
+		echo -e "         $arg"
+	done
+}
+
+# print string in $1 for $2 times
+echo-repeat ()
+{
+    seq  -f $1 -s '' $2; echo
+}
+
+# prints message to stderr
+echo-stderr ()
+{
+	(>&2 echo "$@")
+}
+
+# Get path to .docksal folder using upfind
+get_project_path ()
+{
+	if [[ "$DOCKSAL_PATH" == "" ]]; then
+		DOCKSAL_PATH=$(upfind ".docksal")
+	fi
+	# If we reached $HOME, then we did not find the project root.
+	if [[ "$DOCKSAL_PATH" != "$HOME" ]]; then
+		echo "$DOCKSAL_PATH"
+	fi
+}
+
+is_linux ()
+{
+	[[ "$OS_TYPE" == "Linux" ]]
+}
+
+# TODO: drop this function in May 2020 to complete Babun deprecation
+is_windows ()
+{
+	[[ "$OS_TYPE" == "Cygwin" ]]
+}
+
+is_wsl ()
+{
+	[[ "$OS_TYPE" == "WSL" ]]
+}
+
+is_mac ()
+{
+	[[ "$OS_TYPE" == "Darwin" ]]
+}
+
+install_linux ()
+{
+# Install mkcert ssl tool
+	echo-green "Installing Mkcert..."
+	curl -fL# "$URL_MKCERT_NIX" -o "$MKCERT_BIN" && \
+	chmod +x "$MKCERT_BIN" && \
+	if [ "$(mkcert --version 2>&1 >/dev/null)" ]; then
+		echo-red "Mkcert installation/upgrade has failed."
+		exit 1
+        fi
+	mkcert -install
+	echo-green "mkcert version $(mkcert --version) installed"
+}
+
+install_windows ()
+{
+# Install mkcert ssl tool
+	echo-green "Installing Mkcert..."
+	curl -fL# "$URL_MKCERT_WIN" -o "$MKCERT_BIN" && \
+	chmod +x "$MKCERT_BIN" && \
+	if [ "$(mkcert --version 2>&1 >/dev/null)" ]; then
+		echo-red "Mkcert installation/upgrade has failed."
+		exit 1
+        fi
+	mkcert -install
+	echo-green "mkcert version $(mkcert --version) installed"
+}
+
+install_mac ()
+{
+# Install mkcert ssl tool
+	echo-green "Installing Mkcert..."
+	curl -fL# "$URL_MKCERT_MAC" -o "$MKCERT_BIN" && \
+	chmod +x "$MKCERT_BIN" && \
+	if [ "$(mkcert --version 2>&1 >/dev/null)" ]; then
+		echo-red "Mkcert installation/upgrade has failed."
+		exit 1
+        fi
+	mkcert -install
+	echo-green "mkcert version $(mkcert --version) installed"
+}
+
+
+if [ "$(mkcert --version 2>&1 >/dev/null)" ]; then
+	echo "  NOT in CONFIG_DIR and mkcert not here"
+	if is_linux; then
+	  install_linux
+	fi
+	if is_windows; then
+	  install_windows
+	fi
+	if is_wsl; then
+	  install_linux
+	fi
+	if is_mac; then
+	  install_mac
+	fi
+else
+	echo-green "mkcert allready installed; found $(which mkcert)"
+fi
+
+if [ ! "${ADDON_ROOT}" == "$MKCERT_ADDON" ]; then
+	mkdir -p ${MKCERT_ADDON}
+	mv ${ADDON_ROOT}/mkcert ${MKCERT_ADDON}
+	mv ${ADDON_ROOT}/mkcert.pre-install ${MKCERT_ADDON}
+	rm -rf ${ADDON_ROOT}
+	echo-green "Moved addon mkcert to global docksal config"
+fi
+

--- a/mkcert/mkcert.pre-install
+++ b/mkcert/mkcert.pre-install
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CONFIG_DIR="$HOME/.docksal"
+CONFIG_CERTS=${CONFIG_CERTS:-$HOME/.docksal/certs}
 MKCERT_BIN="$CONFIG_DIR/bin/mkcert"
 MKCERT_ADDON="$CONFIG_DIR/addon/mkcert"
 
@@ -115,7 +116,7 @@ install_linux ()
 		echo-red "Mkcert installation/upgrade has failed."
 		exit 1
         fi
-	mkcert -install
+	sudo mkcert -install
 	echo-green "mkcert version $(mkcert --version) installed"
 }
 
@@ -143,7 +144,7 @@ install_mac ()
 		echo-red "Mkcert installation/upgrade has failed."
 		exit 1
         fi
-	mkcert -install
+	sudo mkcert -install
 	echo-green "mkcert version $(mkcert --version) installed"
 }
 
@@ -162,6 +163,7 @@ if [ "$(mkcert --version 2>&1 >/dev/null)" ]; then
 	if is_mac; then
 	  install_mac
 	fi
+	mkdir -p "${CONFIG_CERTS}"
 else
 	echo-green "mkcert allready installed; found $(which mkcert)"
 fi


### PR DESCRIPTION
In https://github.com/docksal/docksal/pull/1274 is mentioned including mkcert in `fin` is not an option because the security concerns.

Maybe this is a possible solution?
- it installs mkcert as a global addon (is already possible: try `fin addon install example --global`) even when --global is not given.
- it installs the mkcert executable in $HOME/.docksal/bin/mkcert

But I am not sure it will install in all environments (Ubuntu, Centos, Mac, Windows, WSL) because the installation [instructions](https://github.com/FiloSottile/mkcert#installation) mentions  to install 'nss' also in all systems (in my desktop it was already installed).

What to do? 
- Forget about it?
- Let the user install mkcert themself on their systems, just to avoid our responsibility?

PS: I modified my docksal/vhost-proxy image to redirect http to https.