### PR TITLE
Feature/uli addon  #36 add variable to allow ssl link by default

### DIFF
--- a/uli/README.md
+++ b/uli/README.md
@@ -10,7 +10,7 @@
 fin uli [-s] [-i] [@drushsitealias] [ drush uli options ]
 ```
 
-* `-s` outputs the login url with https instead of default of https
+* `-s` outputs the login url with https instead of default of http
 * Setting `DOCKSAL_ADDON_ULI_USE_HTTPS=1` in the global `docksal.env` or in a project's `docksal-local.env` will force the use of https in the link output unless overridden by the `-i` option.
 * `-i` outputs the login url with the default http
 * Drush site alias - useful for Drupal multi-site installations

--- a/uli/README.md
+++ b/uli/README.md
@@ -7,11 +7,13 @@
 ## Usage
 
 ```
-fin uli [-s] [@drushsitealias] [ drush uli options ]
+fin uli [-s] [-i] [@drushsitealias] [ drush uli options ]
 ```
 
 * `-s` outputs the login url with https instead of default of https
+* Setting `DOCKSAL_ADDON_ULI_USE_HTTPS=1` in the global `docksal.env` or in a project's `docksal-local.env` will force the use of https in the link output unless overridden by the `-i` option.
+* `-i` outputs the login url with the default http
 * Drush site alias - useful for Drupal multi-site installations
 * Drush uli options are passed in. See [Drush user:login documentation](https://drushcommands.com/drush-9x/user/user:login/) for possible options.
 
-Note: the `-s` option and Drush site alias must be one of the first two given on the command line. Both are optional.
+Note: the `-s` and `-i` options and Drush site alias must be one of the first two given on the command line. Both are optional.

--- a/uli/uli
+++ b/uli/uli
@@ -6,13 +6,17 @@ die ()
 	exit 1
 }
 
-## Generate one time user login link. Add -s to use https in url.
-## Usage fin uli @drushalias -s
-## The drush alias and -s flags are optional.
+## Generate one time user login link. Add -s to use https in url or -i for insecure.
+## Usage fin uli @drushalias -s -i
+## The drush alias and -s  -i flags are optional.
+## Set environmental variable DOCKSAL_ADDON_ULI_USE_HTTPS=1 in either the global docksal.env
+## or the project docksal-local.env file to always use https in the link. Use -i to override.
 
 cd "$PROJECT_ROOT/$DOCROOT" || die "Could not change dir to $PROJECT_ROOT/$DOCROOT"
 
-https=0 # Default to not use https
+# Check the environmental variable DOCKSAL_ADDON_ULI_USE_HTTPS to see if it is set to true.
+# This will be overridden by command line options given in the next section.
+https=${DOCKSAL_ADDON_ULI_USE_HTTPS:-0}  # Default is to not use https
 
 # Check the first two options / arguments given on the the command line for
 # what looks like a Drush site alias or the -s option to use https in the url.
@@ -23,6 +27,9 @@ while [ $count -ne 0 ]; do
             shift 1
         elif [[ $1 == "-s" ]]; then
             https=1
+            shift 1
+        elif [[ $1 == "-i" ]]; then
+            https=0
             shift 1
         fi
         count=$[$count-1]


### PR DESCRIPTION
This fixes #36. I changed the variable setting from the OP value of **true** to **1** to match the other variable settings of this type.
I tested this locally on my Docksal install.