### PR TITLE
Fixes #56 for the MailHog addon …

### DIFF
--- a/mailhog/README.md
+++ b/mailhog/README.md
@@ -10,3 +10,12 @@ fin addon install mailhog
 
 - `fin mailhog disable` to disable
 - `fin mailhog enable` to re-enable
+
+## URL
+
+After the installation using the default `*.docksal` domain name, MailHog will be available at `http://webmail-<project_name>.docksal`.
+
+
+
+## Regressions
+ Previously the url for MailHog could be found at `http://webmail.<project_name>.docksal` or `http://mail.<project_name>.docksal`. This change was made to make it easier to use a LetsEncrypt wildcard certificate, as it is only valid for one level of subdomain.

--- a/mailhog/conf/mailhog.yml
+++ b/mailhog/conf/mailhog.yml
@@ -7,5 +7,5 @@
       - MH_API_BIND_ADDR=0.0.0.0:80
       - MH_UI_BIND_ADDR=0.0.0.0:80
     labels:
-      - io.docksal.virtual-host=webmail.${VIRTUAL_HOST}
+      - io.docksal.virtual-host=mail-${VIRTUAL_HOST}
     user: root


### PR DESCRIPTION
…  using "mail" but it was set to "webmail". It appears that this has been for some time been overridden to the subdomain "mail" upstream in docksal/docksal in `stacks/services.yml`. This was changed in the upstream project from webmail to mail in version 1.7.0.

In order for the domain name to change for the MailHog addon this will need to change the label  in docksal/docksal/ `stacks/services.yml` on this [line](https://github.com/docksal/docksal/blob/8d1dca726a219f63428fe8b04e94f8c4563d775a/stacks/services.yml#L231) to:
```bash
- io.docksal.virtual-host=mail.${VIRTUAL_HOST},mail-${VIRTUAL_HOST}.*
```
replacing the period with at dash.