### PR TITLE
Feature/dbeaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ DISCLAMER: since it is a community driven project it is only smoke-tested and co
 |   [artisan](artisan) | Runs [Laravel's Artisan](https://laravel.com/docs/artisan) command in `cli`. **Requires** artisan pre-installed inside `cli`. | Laravel, Artisan |
 |   [blt](blt) | Acquia BLT tool launcher (requires [BLT installation](https://blog.docksal.io/docksal-and-acquia-blt-1552540a3b9f)) | Drupal |
 |   [codeclimate](codeclimate) | [CodeClimate](https://codeclimate.com/) code quality tool | |
+|   [dbeaver](dbeaver) | Launches [DBeaver](https://dbeaver.io/) with the connection information for current project. | macOS, Linux |
 |   [mailhog](mailhog) | [Mailhog](https://github.com/mailhog/MailHog) e-mail capture service for current project |  |
 |   [mkcert](mkcert) | [mkcert](https://github.com/FiloSottile/mkcert) addon for Docksal |  |
 |   [phpcs](phpcs) | PHP Code Sniffer and Code Beautifier | |

--- a/dbeaver/README.md
+++ b/dbeaver/README.md
@@ -1,0 +1,37 @@
+# DBeaver - Docksal addon
+
+This Docksal addon launches [DBeaver][1] with the connection information from the current project.
+DBeaver is a multi-platform database tool that supports popular database engines like MySQL, PostgreSQL, and more. 
+
+This addon tries to detect the database engine and launches DBeaver with the correct connection settings.
+Currently, only the following database engines can be detected:
+
+* MySQL
+* PostgreSQL
+
+## Installation
+The addon can be installed using the following command:
+
+```bash
+fin addon install dbeaver
+```
+
+## Usage
+Run `fin dbeaver` to launch DBeaver with the connection information from the current project. 
+
+```bash
+fin dbeaver
+```
+
+If the database service name is not `db` or the project has multiple database services, 
+a service name can be provided as the first parameter.
+
+```bash
+fin dbeaver database_container
+```
+
+Note: on macOS AppleScript is used to determine the installation location of DBeaver. 
+When running this script for the first time, a pop-up might ask if it's allowed to execute the AppleScript.
+
+[1]: https://dbeaver.io
+

--- a/dbeaver/dbeaver
+++ b/dbeaver/dbeaver
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+## Opens DBeaver
+##
+## Usage: fin dbeaver [container (default: db)]
+
+# Abort if anything fails
+set -e
+
+info() {
+    echo -e "\033[0;32m${1}\033[0m"
+}
+
+error() {
+    echo -e "\033[1;31m${1}\033[0m"
+}
+
+function detectDBeaver() {
+    local OS
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
+    case $OS in
+        linux*)
+            DBEAVER=$(command -v dbeaver)
+            ;;
+        darwin*)
+            DBEAVER="$(osascript -e 'POSIX path of (path to application "DBeaver")')Contents/MacOS/dbeaver"
+            ;;
+        *)
+            echo "Unknown system: ${OS} is currently not supported!"
+            exit 1
+            ;;
+    esac
+
+    if [[ ! -f "${DBEAVER}" ]]; then
+        error "Error: DBeaver is not installed."
+        if [[ "${OS}" == darwin* ]]; then
+            echo
+            echo "Install DBeaver with brew:"
+            echo
+            echo "  brew cask install dbeaver-community"
+        fi
+        exit 1
+    fi
+}
+
+function getContainerId() {
+    CONTAINER_ID=$(docker ps --all --filter "label=com.docker.compose.service=${DB_SERVICE}" --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" --format '{{.ID}}')
+    if [ -z "${CONTAINER_ID}" ]; then
+        error "Error: Unable to detect database container with name \"${DB_SERVICE}\"."
+        exit 1
+    fi
+}
+
+function detectContainerPort() {
+    CONTAINER_PORT=$(docker ps --filter "id=${CONTAINER_ID}" --format "{{.Ports}}" | sed 's/.*0.0.0.0://g' | sed 's/->.*//g')
+}
+
+function detectDatabaseType() {
+    local ENV_SETTINGS
+    ENV_SETTINGS=$(docker inspect -f '{{range $index, $value := .Config.Env}}{{println $value}}{{end}}' "${CONTAINER_ID}")
+
+    local ENV_SPLIT
+    # shellcheck disable=SC2206
+    IFS=$'\n' ENV_SPLIT=($ENV_SETTINGS)
+
+    local KEY
+    for VALUE in "${ENV_SPLIT[@]}"
+    do
+        KEY=$(echo "${VALUE}" | cut -d '=' -f1)
+
+        if [[ "${KEY}" = "MYSQL_DATABASE" ]]; then
+            DB_TYPE=mysql
+            DB_DATABASE=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^MYSQL_DATABASE/ {print $2}')
+            DB_USER=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^MYSQL_USER/ {print $2}')
+            DB_PASSWORD=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^MYSQL_PASSWORD/ {print $2}')
+            return
+        fi
+
+        if [[ "${KEY}" = "POSTGRES_DB" ]]; then
+            DB_TYPE=postgresql
+            DB_DATABASE=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^POSTGRES_DB/ {print $2}')
+            DB_USER=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^POSTGRES_USER/ {print $2}')
+            DB_PASSWORD=$(echo "${ENV_SETTINGS}" | awk -F'=' '/^POSTGRES_PASSWORD/ {print $2}')
+            return
+        fi
+    done
+}
+
+detectDBeaver
+
+DB_SERVICE=${1:-db}
+getContainerId
+detectContainerPort
+detectDatabaseType
+
+if [[ -z "${DB_TYPE}" ]]; then
+    error "Error: Unable to detect database engine used inside the db container."
+    exit 1
+fi
+
+if [[ -z "${CONTAINER_PORT}" ]]; then
+    error "Error: Unable to detect database mapped port."
+    exit 1
+fi
+
+CONNECTION="driver=${DB_TYPE}|host=localhost|database=${DB_DATABASE:-default}|name=${COMPOSE_PROJECT_NAME}|port=${CONTAINER_PORT}|user=${DB_USER:-user}|password=${DB_PASSWORD:-user}|openConsole=true|connect=true|create=false"
+${DBEAVER} -con "${CONNECTION}" > /dev/null 2>&1 &


### PR DESCRIPTION
I created an addon to launch [DBeaver](https://dbeaver.io/) within the current project a while ago.
DBeaver is a multi-platform database tool that supports popular database engines like MySQL, PostgreSQL, and more.

This addon will launch DBeaver with the connection information from the current project. It will automatically detect a MySQL or PostgreSQL database container. Other database types are currently not supported.

Optionally a container name can be given if multiple database containers exist within a project.
```bash
fin dbeaver [container name]
```

The original repository is located here: https://github.com/CyberJack/dbeaver.
I will archive the repository if this pull request gets accepted.