### PR TITLE
Add support for SequelAce to docksal addons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ DISCLAMER: since it is a community driven project it is only smoke-tested and co
 |   [pma](pma) | [PhpMyAdmin](https://www.phpmyadmin.net/) database management tool | MySQL |
 |   [rabbitmq](rabbitmq) | [RabbitMQ](https://www.rabbitmq.com/) Message Broker | RabbitMQ |
 |   [redis](redis) | Add [Redis](https://redis.io/) to current project |  |
+|   [sequelace](sequelace) | Launches [SequelAce](https://github.com/Sequel-Ace/Sequel-Ace) with the connection information for current project. | macOS |
 |   [sequelpro](sequelpro) | Launches [SequelPro](https://www.sequelpro.com) with the connection information for current project. | macOS |
 |   [simpletest](simpletest) | Runs SimpleTest tests in Drupal 7 and 8 | Drupal |
 |   [sitediff](sitediff) | Runs Sitediff tests in your Docksal project | |

--- a/sequelace/README.md
+++ b/sequelace/README.md
@@ -1,0 +1,3 @@
+# SequelAce Connection
+
+Launches [SequelAce](https://github.com/Sequel-Ace/Sequel-Ace) with the connection information for your project.

--- a/sequelace/sequelace
+++ b/sequelace/sequelace
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+## Opens SequelAce
+##
+## Usage: fin sequelace
+
+# Abort if anything fails
+set -e
+
+container_port=$(docker ps --all --filter 'label=com.docker.compose.service=db' --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME_SAFE}" --format '{{.Ports}}' | sed 's/.*0.0.0.0://g'|sed 's/->.*//g')
+HOST=${VIRTUAL_HOST}
+DB=${MYSQL_DATABASE:-default}
+USER=${MYSQL_USER:-user}
+PASS=${MYSQL_PASSWORD:-user}
+NAME=${COMPOSE_PROJECT_NAME}
+
+PORT=${PORT:-$container_port}
+
+FILENAME=/tmp/docksal-sequelace-${RANDOM}.spf
+cat <<EOT >> $FILENAME
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>ContentFilters</key>
+  <dict/>
+  <key>auto_connect</key>
+  <true/>
+  <key>data</key>
+  <dict>
+    <key>connection</key>
+    <dict>
+      <key>database</key>
+      <string>${DB}</string>
+      <key>host</key>
+      <string>${HOST}</string>
+      <key>name</key>
+      <string>${NAME}</string>
+      <key>user</key>
+      <string>${USER}</string>
+      <key>password</key>
+      <string>${PASS}</string>
+      <key>port</key>
+      <integer>${PORT}</integer>
+      <key>rdbms_type</key>
+      <string>mysql</string>
+    </dict>
+    <key>session</key>
+    <dict/>
+  </dict>
+  <key>encrypted</key>
+  <false/>
+  <key>format</key>
+  <string>connection</string>
+  <key>queryFavorites</key>
+  <array/>
+  <key>queryHistory</key>
+  <array/>
+  <key>rdbms_type</key>
+  <string>mysql</string>
+  <key>version</key>
+  <integer>1</integer>
+</dict>
+</plist>
+EOT
+
+open $FILENAME


### PR DESCRIPTION
SequelAce is the drop in replacement for Sequel Pro on OSX since Sequel Pro has become buggy in the latest versions of OSX.

This PR basically copies the settings from the SequelPro addon and updates it for SequelAce.