### PR TITLE
Create xdebug addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ DISCLAMER: since it is a community driven project it is only smoke-tested and co
 |   [tableplus](tableplus) | Launches [TablePlus](https://www.tableplus.com) with the connection information for current project. | macOS |
 |   [uli](uli) | Generate one time login url for current site | Drupal |
 |   [wkhtmltopdf](wkhtmltopdf) | Installs wkhtmltopdf 0.12.5 with QT compiled in. |  |
+|   [xdebug](xdebug) | Turns [xdebug](https://docs.docksal.io/tools/xdebug/) on or off and restarts docksal |  |

--- a/xdebug/xdebug
+++ b/xdebug/xdebug
@@ -16,7 +16,7 @@ case $1 in
         fin up
         ;;
     *)
-        echo "Please tell me 'on' or 'off'."
+        echo "Usage: fin xdebug <on|off>"
 esac
 
 echo "Set xdebug to $1"

--- a/xdebug/xdebug
+++ b/xdebug/xdebug
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+## Turn Xdebug on or off
+##
+## Usage: fin xdebug [on|off]
+
+set -e
+
+case $1 in
+
+    on)
+        fin config set --env=local XDEBUG_ENABLED=1
+        fin up
+        ;;
+    off)
+        fin config set --env=local XDEBUG_ENABLED=0
+        fin up
+        ;;
+    *)
+        echo "Please tell me 'on' or 'off'."
+esac
+
+echo "Set xdebug to $1"


### PR DESCRIPTION
A very simple addon to turn xdebug on or off (that mirrors [DDEV's function](https://ddev.readthedocs.io/en/latest/users/debugging-profiling/step-debugging/))